### PR TITLE
Allow adding dates from the availability page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -172,7 +172,19 @@
       "participantNameGateHint": "Enter your name or nickname to unlock availability voting.",
       "toggleFailed": "Could not update your availability.",
       "availableCount": "{count, plural, =0 {0 available} one {# available} other {# available}}",
-      "noParticipants": "Nobody is available yet."
+      "noParticipants": "Nobody is available yet.",
+      "addDates": {
+        "title": "Add new dates",
+        "description": "Propose extra dates so everyone can vote on them.",
+        "stage": "Add to list",
+        "submit": "Save new dates",
+        "adding": "Saving...",
+        "alreadyAdded": "This date is already in the list.",
+        "errors": {
+          "dateRequired": "Pick at least one date first.",
+          "addFailed": "Could not add the dates."
+        }
+      }
     }
   },
   "API": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -172,7 +172,19 @@
       "participantNameGateHint": "Renseigne ton prénom ou pseudo pour déverrouiller les disponibilités.",
       "toggleFailed": "Impossible de mettre à jour ta disponibilité.",
       "availableCount": "{count, plural, =0 {0 disponible} one {# disponible} other {# disponibles}}",
-      "noParticipants": "Personne n'est disponible pour l'instant."
+      "noParticipants": "Personne n'est disponible pour l'instant.",
+      "addDates": {
+        "title": "Ajouter de nouvelles dates",
+        "description": "Propose des dates supplémentaires pour que tout le monde puisse voter.",
+        "stage": "Ajouter à la liste",
+        "submit": "Enregistrer les nouvelles dates",
+        "adding": "Enregistrement...",
+        "alreadyAdded": "Cette date est déjà dans la liste.",
+        "errors": {
+          "dateRequired": "Choisis au moins une date d'abord.",
+          "addFailed": "Impossible d'ajouter les dates."
+        }
+      }
     }
   },
   "API": {

--- a/src/app/actions/planning.ts
+++ b/src/app/actions/planning.ts
@@ -17,6 +17,11 @@ type ToggleAvailabilityInput = {
   participantName?: string
 }
 
+type AddPlanningDatesInput = {
+  eventId: string
+  dates: string[]
+}
+
 function toDateKey(date: Date) {
   return date.toISOString().slice(0, 10)
 }
@@ -162,6 +167,52 @@ export async function getPlanningEventById(id: string) {
       dateKey: toDateKey(option.date),
     })),
   }
+}
+
+export async function addPlanningDates({ eventId, dates }: AddPlanningDatesInput) {
+  if (!eventId?.trim()) {
+    throw new Error('Event id is required')
+  }
+
+  const event = await prisma.planningEvent.findUnique({
+    where: { id: eventId },
+    include: {
+      dateOptions: {
+        select: { date: true },
+      },
+    },
+  })
+
+  if (!event) {
+    throw new Error('Event not found')
+  }
+
+  const existingDateKeys = new Set(event.dateOptions.map((option) => toDateKey(option.date)))
+
+  const normalizedDates = Array.from(
+    new Set(
+      dates
+        .map((dateString) => dateString.trim())
+        .filter(Boolean)
+    )
+  )
+    .filter((dateString) => !existingDateKeys.has(dateString))
+    .sort()
+
+  if (normalizedDates.length === 0) {
+    throw new Error('No new date to add')
+  }
+
+  await prisma.planningDateOption.createMany({
+    data: normalizedDates.map((dateString) => ({
+      eventId,
+      date: normalizeDate(dateString),
+    })),
+  })
+
+  revalidatePath(`/date-planner/${eventId}`)
+
+  return { added: normalizedDates.length }
 }
 
 export async function toggleAvailability({ eventId, dateOptionId, participantName }: ToggleAvailabilityInput) {

--- a/src/app/date-planner/[id]/page.tsx
+++ b/src/app/date-planner/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from "next-intl/server"
 
 import { auth } from "@/app/api/auth/[...nextauth]/auth"
 import { getPlanningEventById } from "@/app/actions/planning"
+import PlanningAddDates from "@/components/PlanningAddDates"
 import PlanningAvailabilityBoard from "@/components/PlanningAvailabilityBoard"
 
 interface DatePlannerEventPageProps {
@@ -52,6 +53,11 @@ const DatePlannerEventPage = async ({ params }: DatePlannerEventPageProps) => {
         dateOptions={dateOptions}
         currentUserId={session?.user?.id}
         currentUserName={session?.user?.name}
+      />
+
+      <PlanningAddDates
+        eventId={event.id}
+        existingDateKeys={event.dateOptions.map((option) => option.dateKey)}
       />
     </div>
   )

--- a/src/components/PlanningAddDates.tsx
+++ b/src/components/PlanningAddDates.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import { useMemo, useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { useLocale, useTranslations } from "next-intl"
+
+import { addPlanningDates } from "@/app/actions/planning"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useToast } from "@/components/ui/use-toast"
+
+type PlanningAddDatesProps = {
+  eventId: string
+  existingDateKeys: string[]
+}
+
+function sortDateKeys(dateKeys: string[]) {
+  return [...dateKeys].sort((left, right) => left.localeCompare(right))
+}
+
+const PlanningAddDates = ({ eventId, existingDateKeys }: PlanningAddDatesProps) => {
+  const t = useTranslations("DatePlanner.event.addDates")
+  const locale = useLocale()
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const [pendingDate, setPendingDate] = useState("")
+  const [stagedDates, setStagedDates] = useState<string[]>([])
+  const [isPending, startTransition] = useTransition()
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        weekday: "short",
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      }),
+    [locale]
+  )
+
+  const stageDate = () => {
+    const trimmed = pendingDate.trim()
+    if (!trimmed) return
+
+    if (existingDateKeys.includes(trimmed) || stagedDates.includes(trimmed)) {
+      toast({ title: t("alreadyAdded"), variant: "destructive" })
+      return
+    }
+
+    setStagedDates((previous) => sortDateKeys([...previous, trimmed]))
+    setPendingDate("")
+  }
+
+  const removeStaged = (dateKey: string) => {
+    setStagedDates((previous) => previous.filter((existing) => existing !== dateKey))
+  }
+
+  const submit = () => {
+    if (stagedDates.length === 0) {
+      toast({ title: t("errors.dateRequired"), variant: "destructive" })
+      return
+    }
+
+    startTransition(async () => {
+      try {
+        await addPlanningDates({ eventId, dates: stagedDates })
+        setStagedDates([])
+        router.refresh()
+      } catch (error) {
+        toast({
+          title: t("errors.addFailed"),
+          description: error instanceof Error ? error.message : undefined,
+          variant: "destructive",
+        })
+      }
+    })
+  }
+
+  return (
+    <div className="glassPanel flex flex-col gap-3">
+      <h2 className="text-xl font-semibold">{t("title")}</h2>
+      <p className="text-sm text-muted-foreground">{t("description")}</p>
+
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Input
+          type="date"
+          value={pendingDate}
+          onChange={(event) => setPendingDate(event.target.value)}
+          disabled={isPending}
+        />
+        <Button type="button" variant="outline" onClick={stageDate} disabled={isPending || !pendingDate}>
+          {t("stage")}
+        </Button>
+      </div>
+
+      {stagedDates.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {stagedDates.map((dateKey) => (
+            <Button
+              key={dateKey}
+              type="button"
+              variant="outline"
+              onClick={() => removeStaged(dateKey)}
+              disabled={isPending}
+            >
+              {dateFormatter.format(new Date(`${dateKey}T00:00:00.000Z`))}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      <Button type="button" onClick={submit} disabled={isPending || stagedDates.length === 0}>
+        {isPending ? t("adding") : t("submit")}
+      </Button>
+    </div>
+  )
+}
+
+export default PlanningAddDates


### PR DESCRIPTION
## Summary
- New `PlanningAddDates` panel on `/date-planner/[id]` lets participants propose extra dates without recreating the event.
- New `addPlanningDates` server action dedupes against existing date options and revalidates the page.
- FR/EN translations added.

## Test plan
- [ ] Open an existing event, add a new date, confirm it appears as a votable option.
- [ ] Try adding a date that already exists — should be rejected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ctpn9DPoc3c9bWDY4KmQwp)_