### PR TITLE
Add max width to isolated date-planner layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,7 +62,7 @@ export default async function RootLayout({
           >
             <SessionProvider>
               {isIsolated ? (
-                <main className="min-h-screen w-full relative z-10">
+                <main className="min-h-screen w-full max-w-5xl mx-auto p-3 sm:p-8 relative z-10">
                   <PageTransition>
                     {children}
                   </PageTransition>


### PR DESCRIPTION
Adds `max-w-5xl` and standard padding to the isolated date-planner main container so content doesn't stretch full width.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LR5zdEAifpU1shkps7kaRN)_